### PR TITLE
Add -std=c++11 flag to compile lambdas

### DIFF
--- a/ext/fast_statistics/extconf.rb
+++ b/ext/fast_statistics/extconf.rb
@@ -8,6 +8,9 @@ if ENV["DEBUG"]
   $defs << "-DDEBUG"
 end
 
+# Compile with C++11
+$CXXFLAGS += " -std=c++11 "
+
 # Disable warnings
 [
   / -Wdeclaration-after-statement/,


### PR DESCRIPTION
This fixes compilation on clang (which appears not to default to C++11 or higher, at least on version 12.0.5 installed by Xcode) by specifying C++11 as the standard.